### PR TITLE
Additional .exr support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Install Python bindings
 ### 4. Install Imagemagick
 
 Mac:
-`brew install imagemagick`
+`brew install imagemagick  --with-openexr`
 
 Ubuntu:
-`sudo apt-get install imagemagick`
+`sudo apt-get install imagemagick --with-openexr` 
 
 Author
 ------

--- a/README.md
+++ b/README.md
@@ -1,16 +1,49 @@
-exrsplit - Split a multi-layer exr image into multiple files
+exrsplit
+========
+> Split a multi-layer exr image into multiple files
 
-.exr files are very useful, with a high compression, support for high quality and multiple layers.
-However, many programs don't support loading multi-layer, only files with the standard 3 or 4 color
-channels. This program uses the OpenEXR python implementation to split a multi-layer exr image into
-many exr images. The output may be either single channel (with 3-4 images for each layer) or RGB/RGBA
-and the program supports conversion to png using imagemagick.
+About .exr
+-----
+.exr files are very useful, with a high compression, support for high quality and multiple layers. However, many programs don't support loading multi-layer, only files with the standard 3 or 4 color channels. This program uses the OpenEXR python implementation to split a multi-layer exr image into many exr images. The output may be either single channel (with 3-4 images for each layer) or RGB/RGBA and the program supports conversion to png using imagemagick.
 
-To use the program, install the development packages for OpenEXR, the python interface and imagemagick.
-In Ubuntu, the packages libopenexr-dev, python, python-setuptools and imagemagick should make it.
-Then install the python interface with "easy_install -U openexr".
+Usage
+-----
 
-The program was designed to work with Blender EXR output and tested with them, but should work with
-files from other programs, too. If you find bugs, add an issue in github :)
+### 1. Setting up
+On Mac OSX, install Homebrew:
+`ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
 
-Future plans: rewrite in C++ with multi-core conversion of the images.
+Install wget with Homebrew:
+`brew install wget`
+
+Make sure Pip is installed:
+`wget https://bootstrap.pypa.io/get-pip.py`
+
+`sudo python get-pip.py`
+
+### 2. Install openexr
+
+Mac:
+
+`brew install openexr`
+
+Ubuntu:
+
+`sudo apt-get install libopenexr-dev`
+
+### 3. Install Python bindings
+
+Install Python bindings
+`sudo pip install OpenEXR`
+
+### 4. Install Imagemagick
+
+Mac:
+`brew install imagemagick`
+
+Ubuntu:
+`sudo apt-get install imagemagick`
+
+Author
+------
+Originally written by Tiago Shibata (https://github.com/tiagoshibata).

--- a/exrsplit
+++ b/exrsplit
@@ -13,6 +13,7 @@ def usage():
 			'\t-m\t\tMerge channels (default)\n'
 			'\t-s\t\tSplit channels\n'
 			'\t-v\t\tVerbose mode\n'
+			'\t-n\t\tRemove period from channel name \n\t\t\t(may fix Python \'KeyError\')\n'
 			'See "man exrsplit" for more information.')
 	exit(1)
 
@@ -28,6 +29,9 @@ output_format = 0	# 0 = exr, 1 = png
 verbose = False
 merge = True		# merge channels from the same layer in a single image
 
+# Defaulting to the channel syntax for Blender,
+# <layer name>.<color channel>
+periodInChannelName = True 
 
 for arg in argv[1:-1]:
 	if arg == '-exr':
@@ -40,6 +44,8 @@ for arg in argv[1:-1]:
 		merge = False
 	elif arg == '-v':
 		verbose = True
+	elif arg == '-n':
+		periodInChannelName = False
 	else:
 		print 'Unknown option: ' + arg
 		usage()
@@ -66,6 +72,10 @@ if merge:
 	# in a dictionary.
 	# Blender names the channels as <layer name>.<color channel> (eg. RenderLayer.Combined.r).
 	# The search is required since the layers aren't kept in sorted sequence
+	# 
+	# Other programs (e.g. Terragen 3) use the format <layer name><color channel> (without a 
+	# period).
+
 	outfiles = {}	# the dictionary keeps each layer as a key with the channels as a list
 	for layer in header['channels']:
 		if verbose:
@@ -86,8 +96,10 @@ if merge:
 		out_pixel_formats = {}
 		for channel in outfiles[layer]:
 			# For each channel, let's copy the same channel format from the original layer:
-			out_header['channels'][channel] = header['channels'][layer + '.' + channel]
-			out_pixel_formats[channel] = exr_file.channel(layer + '.' + channel)
+			separater = '.' if periodInChannelName else ''
+
+			out_header['channels'][channel] = header['channels'][layer + separater + channel]
+			out_pixel_formats[channel] = exr_file.channel(layer + separater  + channel)
 		if verbose:
 			print str(i) + '/' + str(totalfiles) + '\tGenerating ' + layer + '.exr with channels ' + str(out_header['channels'].keys())
 			i += 1


### PR DESCRIPTION
Added support for .exr files with the channel format `<layer name><color channel>` using the using -n parameter (no period). Terragen 3 is an example of a program that uses this format (and throws a KeyError with the default `<layer name>.<color channel>` format)

Modified README for accessibility, and added instructions for Mac OSX.

I have found that if Imagemagick is installed using Homebrew without the `--with-openexr` build parameter it is unable to split the layers as .png files. I have included this in the README instructions.