### PR TITLE
Added layer listing and layer selection when splitting

### DIFF
--- a/exrsplit/__main__.py
+++ b/exrsplit/__main__.py
@@ -173,7 +173,7 @@ def list_exr(args):
 def main(args):
     if args.merge:
         merge_exr(args)
-    elif args.list is not None:
+    elif args.list:
         list_exr(args)
     else:
         split_exr(args)

--- a/exrsplit/__main__.py
+++ b/exrsplit/__main__.py
@@ -13,6 +13,8 @@ def _parse_args():
     parser.add_argument('-s', '--split-channels', action='store_true', help='Create a file for each channel instead ' +
                         'of per layer. Data channels (eg. depth, shadows or mask) are saved as grayscale ' +
                         'representations of their data.')
+    parser.add_argument('--layer', action='append', help='Layer or Layer.channel to split OpenEXR in')
+    parser.add_argument('-l', '--list', action='store_true', help='List all layers in given OpenEXR image')
     parser.add_argument('--view', action='append',
                         help='Treat given prefix as a view instead of a layer. ' +
                         'First view is treated as the default view.')
@@ -113,7 +115,10 @@ def split_exr(args):
         exr = _open_inputfile(inputfile)
         try:
             header = exr.header()
-            channels = [exrsplit.EXRChannel(header, layer) for layer in header['channels']]
+            if args.layer:
+                channels = [exrsplit.EXRChannel(header, layer) for layer in header['channels'] if layer.startswith(tuple(args.layer))]
+            else:
+                channels = [exrsplit.EXRChannel(header, layer) for layer in header['channels']]
             if args.split_channels:
                 grouped_channels = [[x] for x in channels]
             else:
@@ -123,6 +128,7 @@ def split_exr(args):
                     target_file = '{}.{}.exr'.format(exrsplit.output_file_name(layer[0]), layer[0].channel)
                 else:
                     target_file = '{}.exr'.format(exrsplit.output_file_name(layer[0]))
+                target_file = '{}_{}'.format(os.path.basename(os.path.splitext(inputfile)[0]), target_file)
                 print('{}/{} - Saving {} channels to {}'.format(layer_i + 1, len(grouped_channels),
                                                                 len(layer), target_file))
                 out_header = _create_output_header(header)
@@ -142,9 +148,28 @@ def split_exr(args):
             exr.close()
 
 
+def list_exr(args):
+    for inputfile in args.image:
+        exr = _open_inputfile(inputfile)
+        try:
+            header = exr.header()
+            if args.layer:
+                channels = [exrsplit.EXRChannel(header, layer) for layer in header['channels'] if layer.startswith(tuple(args.layer))]
+            else:
+                channels = [exrsplit.EXRChannel(header, layer) for layer in header['channels']]
+            grouped_channels = exrsplit.group_channels(channels)
+            for layer_i, layer in enumerate(grouped_channels):
+                layer_channels = ",".join(sorted([str(x.channel) for x in layer]))
+                print('{}/{} - Layer: {}, Channels: ({})'.format(layer_i + 1, len(grouped_channels), layer[0].layer, layer_channels))
+        finally:
+            exr.close()
+
+
 def main(args):
     if args.merge:
         merge_exr(args)
+    elif args.list:
+        list_exr(args)
     else:
         split_exr(args)
 

--- a/exrsplit/__main__.py
+++ b/exrsplit/__main__.py
@@ -13,8 +13,9 @@ def _parse_args():
     parser.add_argument('-s', '--split-channels', action='store_true', help='Create a file for each channel instead ' +
                         'of per layer. Data channels (eg. depth, shadows or mask) are saved as grayscale ' +
                         'representations of their data.')
-    parser.add_argument('--layer', action='append', help='Layer or Layer.channel to split OpenEXR in')
-    parser.add_argument('-l', '--list', action='store_true', help='List all layers in given OpenEXR image')
+    parser.add_argument('-p', '--prefix', action='store_true', help='Prefix image filename to output filename')
+    parser.add_argument('--layer', action='append', help='Split only selected Layers')
+    parser.add_argument('-l', '--list', action='store_true', help='List layers from images')
     parser.add_argument('--view', action='append',
                         help='Treat given prefix as a view instead of a layer. ' +
                         'First view is treated as the default view.')
@@ -129,7 +130,8 @@ def split_exr(args):
                     target_file = '{}.{}.exr'.format(exrsplit.output_file_name(layer[0]), layer[0].channel)
                 else:
                     target_file = '{}.exr'.format(exrsplit.output_file_name(layer[0]))
-                target_file = '{}_{}'.format(os.path.basename(os.path.splitext(inputfile)[0]), target_file)
+                if args.prefix:
+                    target_file = '{}_{}'.format(os.path.basename(os.path.splitext(inputfile)[0]), target_file)
                 print('{}/{} - Saving {} channels to {}'.format(layer_i + 1, len(grouped_channels),
                                                                 len(layer), target_file))
                 out_header = _create_output_header(header)
@@ -171,12 +173,13 @@ def list_exr(args):
 
 
 def main(args):
-    if args.merge:
-        merge_exr(args)
-    elif args.list:
+    if args.list:
         list_exr(args)
+    elif args.merge:
+        merge_exr(args)
     else:
         split_exr(args)
+
 
 if __name__ == '__main__':
     main(_parse_args())

--- a/exrsplit/__main__.py
+++ b/exrsplit/__main__.py
@@ -115,8 +115,9 @@ def split_exr(args):
         exr = _open_inputfile(inputfile)
         try:
             header = exr.header()
-            if args.layer:
-                channels = [exrsplit.EXRChannel(header, layer) for layer in header['channels'] if layer.startswith(tuple(args.layer))]
+            if args.layer is not None:
+                channels = [exrsplit.EXRChannel(header, layer) for layer in header['channels']
+                            if layer.startswith(tuple(args.layer))]
             else:
                 channels = [exrsplit.EXRChannel(header, layer) for layer in header['channels']]
             if args.split_channels:
@@ -153,14 +154,18 @@ def list_exr(args):
         exr = _open_inputfile(inputfile)
         try:
             header = exr.header()
-            if args.layer:
-                channels = [exrsplit.EXRChannel(header, layer) for layer in header['channels'] if layer.startswith(tuple(args.layer))]
+            if args.layer is not None:
+                channels = [exrsplit.EXRChannel(header, layer) for layer in header['channels']
+                            if layer.startswith(tuple(args.layer))]
             else:
                 channels = [exrsplit.EXRChannel(header, layer) for layer in header['channels']]
             grouped_channels = exrsplit.group_channels(channels)
             for layer_i, layer in enumerate(grouped_channels):
                 layer_channels = ",".join(sorted([str(x.channel) for x in layer]))
-                print('{}/{} - Layer: {}, Channels: ({})'.format(layer_i + 1, len(grouped_channels), layer[0].layer, layer_channels))
+                print('{}/{} - Layer: {}, Channels: ({})'.format(layer_i + 1,
+                                                                 len(grouped_channels),
+                                                                 layer[0].layer,
+                                                                 layer_channels))
         finally:
             exr.close()
 
@@ -168,7 +173,7 @@ def list_exr(args):
 def main(args):
     if args.merge:
         merge_exr(args)
-    elif args.list:
+    elif args.list is not None:
         list_exr(args)
     else:
         split_exr(args)

--- a/exrsplit/exrsplit.py
+++ b/exrsplit/exrsplit.py
@@ -108,8 +108,6 @@ class EXRChannel:
         self.fullname = fullname
         self.view = get_view(header, fullname)
         self.layer = _get_layer(self.view, fullname)
-        if not self.layer:
-            self.layer = "default"
         self.channel = fullname.rsplit('.', 1)[-1]
         self.channel_type = _get_channel_type(self.channel)
 

--- a/exrsplit/exrsplit.py
+++ b/exrsplit/exrsplit.py
@@ -108,6 +108,8 @@ class EXRChannel:
         self.fullname = fullname
         self.view = get_view(header, fullname)
         self.layer = _get_layer(self.view, fullname)
+        if not self.layer:
+            self.layer = "default"
         self.channel = fullname.rsplit('.', 1)[-1]
         self.channel_type = _get_channel_type(self.channel)
 

--- a/tests/cmdargs.py
+++ b/tests/cmdargs.py
@@ -1,3 +1,3 @@
 import collections
 
-CmdArgs = collections.namedtuple('CmdArgs', ['split_channels', 'merge', 'image', 'list'])
+CmdArgs = collections.namedtuple('CmdArgs', ['split_channels', 'merge', 'image', 'list', 'layer'])

--- a/tests/cmdargs.py
+++ b/tests/cmdargs.py
@@ -1,3 +1,3 @@
 import collections
 
-CmdArgs = collections.namedtuple('CmdArgs', ['split_channels', 'merge', 'image', 'list', 'layer'])
+CmdArgs = collections.namedtuple('CmdArgs', ['split_channels', 'merge', 'image', 'prefix', 'list', 'layer'])

--- a/tests/cmdargs.py
+++ b/tests/cmdargs.py
@@ -1,3 +1,3 @@
 import collections
 
-CmdArgs = collections.namedtuple('CmdArgs', ['split_channels', 'merge', 'image'])
+CmdArgs = collections.namedtuple('CmdArgs', ['split_channels', 'merge', 'image', 'list'])

--- a/tests/test_exrsplit___main__.py
+++ b/tests/test_exrsplit___main__.py
@@ -37,13 +37,13 @@ def test_split_exr_layers(mock___open_inputfile, mock_OpenEXR_OutputFile):
 
     mock___open_inputfile.assert_called_once_with('test.exr')
     mock_OpenEXR_OutputFile.assert_has_calls([
-        call('car.exr', {
+        call('test_car.exr', {
             'channels': {'R': {}},
             'comments': b'Processed by exrsplit',
         }),
         call().writePixels(ANY),
         call().close(),
-        call('default_layer.exr', {
+        call('test_default_layer.exr', {
             'channels': {'R': {}, 'G': {}},
             'comments': b'Processed by exrsplit',
         }),

--- a/tests/test_exrsplit___main__.py
+++ b/tests/test_exrsplit___main__.py
@@ -5,8 +5,8 @@ from cmdargs import CmdArgs
 
 
 @pytest.mark.parametrize('flags', [
-    (CmdArgs(split_channels=False, merge=True, list=False, layer=None, image=['a', 'b'])),
-    (CmdArgs(split_channels=True, merge=True, list=False, layer=None, image=['a', 'b', 'c'])),
+    (CmdArgs(split_channels=False, merge=True, prefix=False, list=False, layer=None, image=['a', 'b'])),
+    (CmdArgs(split_channels=True, merge=True, prefix=False, list=False, layer=None, image=['a', 'b', 'c'])),
 ])
 def test_incompatible_flags(flags):
     with pytest.raises(SystemExit):
@@ -32,18 +32,18 @@ def test_split_exr_layers(mock___open_inputfile, mock_OpenEXR_OutputFile):
     mock_exr = MagicMock()
     mock_exr.header = lambda: {'channels': {'R': {}, 'G': {}, 'car.R': {}}}
     mock___open_inputfile.side_effect = lambda x: mock_exr
-    args = CmdArgs(split_channels=False, merge=False, list=False, layer=None, image=['test.exr'])
+    args = CmdArgs(split_channels=False, merge=False, prefix=False, list=False, layer=None, image=['test.exr'])
     exrsplit_main.split_exr(args)
 
     mock___open_inputfile.assert_called_once_with('test.exr')
     mock_OpenEXR_OutputFile.assert_has_calls([
-        call('test_car.exr', {
+        call('car.exr', {
             'channels': {'R': {}},
             'comments': b'Processed by exrsplit',
         }),
         call().writePixels(ANY),
         call().close(),
-        call('test_default_layer.exr', {
+        call('default_layer.exr', {
             'channels': {'R': {}, 'G': {}},
             'comments': b'Processed by exrsplit',
         }),

--- a/tests/test_exrsplit___main__.py
+++ b/tests/test_exrsplit___main__.py
@@ -5,8 +5,8 @@ from cmdargs import CmdArgs
 
 
 @pytest.mark.parametrize('flags', [
-    (CmdArgs(split_channels=False, merge=True, list=False, image=['a', 'b'])),
-    (CmdArgs(split_channels=True, merge=True, list=False, image=['a', 'b', 'c'])),
+    (CmdArgs(split_channels=False, merge=True, list=False, layer=None, image=['a', 'b'])),
+    (CmdArgs(split_channels=True, merge=True, list=False, layer=None, image=['a', 'b', 'c'])),
 ])
 def test_incompatible_flags(flags):
     with pytest.raises(SystemExit):
@@ -32,7 +32,7 @@ def test_split_exr_layers(mock___open_inputfile, mock_OpenEXR_OutputFile):
     mock_exr = MagicMock()
     mock_exr.header = lambda: {'channels': {'R': {}, 'G': {}, 'car.R': {}}}
     mock___open_inputfile.side_effect = lambda x: mock_exr
-    args = CmdArgs(split_channels=False, merge=False, list=False, image=['test.exr'])
+    args = CmdArgs(split_channels=False, merge=False, list=False, layer=None, image=['test.exr'])
     exrsplit_main.split_exr(args)
 
     mock___open_inputfile.assert_called_once_with('test.exr')

--- a/tests/test_exrsplit___main__.py
+++ b/tests/test_exrsplit___main__.py
@@ -5,8 +5,8 @@ from cmdargs import CmdArgs
 
 
 @pytest.mark.parametrize('flags', [
-    (CmdArgs(split_channels=False, merge=True, image=['a', 'b'])),
-    (CmdArgs(split_channels=True, merge=True, image=['a', 'b', 'c'])),
+    (CmdArgs(split_channels=False, merge=True, list=False, image=['a', 'b'])),
+    (CmdArgs(split_channels=True, merge=True, list=False, image=['a', 'b', 'c'])),
 ])
 def test_incompatible_flags(flags):
     with pytest.raises(SystemExit):
@@ -32,7 +32,7 @@ def test_split_exr_layers(mock___open_inputfile, mock_OpenEXR_OutputFile):
     mock_exr = MagicMock()
     mock_exr.header = lambda: {'channels': {'R': {}, 'G': {}, 'car.R': {}}}
     mock___open_inputfile.side_effect = lambda x: mock_exr
-    args = CmdArgs(split_channels=False, merge=False, image=['test.exr'])
+    args = CmdArgs(split_channels=False, merge=False, list=False, image=['test.exr'])
     exrsplit_main.split_exr(args)
 
     mock___open_inputfile.assert_called_once_with('test.exr')

--- a/tests/test_openexr_images.py
+++ b/tests/test_openexr_images.py
@@ -29,7 +29,7 @@ if has_submodule:
 @pytest.mark.parametrize('image', openexr_images)
 def test_split_image(image):
     try:
-        exrsplit_main.main(CmdArgs(split_channels=False, merge=False, image=[image]))
+        exrsplit_main.main(CmdArgs(split_channels=False, merge=False, list=False, layer=None, image=[image]))
     except IOError as e:
         if "The file format version number's flag field contains unrecognized flags" in str(e):
             pytest.xfail('Long header and channel names not backwards compatible with libIlmImf<2.0')

--- a/tests/test_openexr_images.py
+++ b/tests/test_openexr_images.py
@@ -20,6 +20,7 @@ def image_path(dirpath, filename):
         return pytest.mark.skip('pythonopenexr crash in Python 3')  # investigate this segfault
     return os.path.join(dirpath, filename)
 
+
 openexr_images = []
 if has_submodule:
     for dirpath, _, filenames in os.walk(openexr_images_submodule):
@@ -29,7 +30,8 @@ if has_submodule:
 @pytest.mark.parametrize('image', openexr_images)
 def test_split_image(image):
     try:
-        exrsplit_main.main(CmdArgs(split_channels=False, merge=False, prefix=False, list=False, layer=None, image=[image]))
+        exrsplit_main.main(CmdArgs(split_channels=False, merge=False, prefix=False, list=False, layer=None,
+                                   image=[image]))
     except IOError as e:
         if "The file format version number's flag field contains unrecognized flags" in str(e):
             pytest.xfail('Long header and channel names not backwards compatible with libIlmImf<2.0')

--- a/tests/test_openexr_images.py
+++ b/tests/test_openexr_images.py
@@ -29,7 +29,7 @@ if has_submodule:
 @pytest.mark.parametrize('image', openexr_images)
 def test_split_image(image):
     try:
-        exrsplit_main.main(CmdArgs(split_channels=False, merge=False, list=False, layer=None, image=[image]))
+        exrsplit_main.main(CmdArgs(split_channels=False, merge=False, prefix=False, list=False, layer=None, image=[image]))
     except IOError as e:
         if "The file format version number's flag field contains unrecognized flags" in str(e):
             pytest.xfail('Long header and channel names not backwards compatible with libIlmImf<2.0')


### PR DESCRIPTION
Added two command line args to list layers in an image and to select layers to be splited. Changed the output file name to "originalfilename_layername.exr" useful when converting many frames in the same folder.